### PR TITLE
Fixes convention not working for Model_Prop_AttributeShortName

### DIFF
--- a/ModelMetadataExtensions/ConventionalModelMetadataProvider.cs
+++ b/ModelMetadataExtensions/ConventionalModelMetadataProvider.cs
@@ -89,10 +89,10 @@ namespace ModelMetadataExtensions {
                         if (!resourceType.PropertyExists(resourceKey)) {
                             continue;
                         }
-
-                        validationAttribute.ErrorMessageResourceType = resourceType;
-                        validationAttribute.ErrorMessageResourceName = resourceKey;
                     }
+
+                    validationAttribute.ErrorMessageResourceType = resourceType;
+                    validationAttribute.ErrorMessageResourceName = resourceKey;
                 }
             }
         }


### PR DESCRIPTION
This fixes #2

This actually affects inbuilt annotations like RegularExpressionAttribute
